### PR TITLE
Ensure parser errors are properly returned

### DIFF
--- a/src/asset-relocator.js
+++ b/src/asset-relocator.js
@@ -39,7 +39,7 @@ function isExpressionReference(node, parent) {
 	return true;
 }
 
-const relocateRegEx = /_\_dirname|_\_filename|require\.main|node-pre-gyp|bindings|define|require\(\s*[^'"]|__non_webpack_require__|process\.versions\.node/;
+const relocateRegEx = /(?<![a-z])(_\_dirname|_\_filename|require\.main|node-pre-gyp|bindings|define|require\(\s*[^'"]|__non_webpack_require__|process\.versions\.node)/;
 
 const stateMap = new Map();
 let lastState;
@@ -259,8 +259,14 @@ module.exports = async function (content) {
   }
   catch (e) {}
   if (!ast) {
-    ast = acorn.parse(code, { sourceType: 'module' });
-    isESM = true;
+    try {
+      ast = acorn.parse(code, { sourceType: 'module' });
+      isESM = true;
+    }
+    catch (e) {
+      this.callback(e);
+      return;
+    }
   }
 
   let scope = attachScopes(ast, 'scope');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,6 +2,8 @@ const fs = require("fs");
 const webpack = require("webpack");
 const MemoryFS = require("memory-fs");
 
+jest.setTimeout(20000);
+
 for (const unitTest of fs.readdirSync(`${__dirname}/unit`)) {
   it(`should generate correct output for ${unitTest}`, async () => {
     // simple error test

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,8 +4,12 @@ const MemoryFS = require("memory-fs");
 
 for (const unitTest of fs.readdirSync(`${__dirname}/unit`)) {
   it(`should generate correct output for ${unitTest}`, async () => {
+    // simple error test
+    let shouldError = false;
+    if (unitTest.endsWith('-err'))
+      shouldError = true;
     const testDir = `${__dirname}/unit/${unitTest}`;
-    const expected = fs
+    const expected = !shouldError && fs
       .readFileSync(`${testDir}/output${global.coverage ? '-coverage' : ''}.js`)
       .toString()
       .trim()
@@ -45,12 +49,23 @@ for (const unitTest of fs.readdirSync(`${__dirname}/unit`)) {
     });
     compiler.outputFileSystem = mfs;
   
-    const stats = await new Promise((resolve, reject) => {
-      compiler.run((err, stats) => {
-        if (err) return reject(err);
-        resolve(stats);
+    try {
+      var stats = await new Promise((resolve, reject) => {
+        compiler.run((err, stats) => {
+          if (err) return reject(err);
+          resolve(stats);
+        });
       });
-    });
+    }
+    catch (err) {
+      if (shouldError)
+        return;
+      throw err;
+    }
+    if (shouldError) {
+      expect(stats.compilation.errors.length).toBeGreaterThan(0);
+      return;
+    }
 
     let code;
     try {

--- a/test/unit/syntax-err/input.js
+++ b/test/unit/syntax-err/input.js
@@ -1,0 +1,2 @@
+// if (typeof __filename > 'undefine') {
+  +


### PR DESCRIPTION
This fixes the issue of parser rejection errors not being correctly propagated back to Webpack.

In addition, the asset relocator has a filter regex it uses to determine if a full parse and analysis is needed or not. Due to the lack of the use of word boundaries, this is still overclassifying. So I've restricted the word boundaries a little that should aid in performance as well.

Fixes #7 