### PR TITLE
Implement debugLog, restrict asset emission to package boundary

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ Any `.node` files included will also support binary relocation.
             existingAssetNames: []
             wrapperCompatibility: false, // optional, default
             escapeNonAnalyzableRequires: false, // optional, default
-
+            debugLog: false, // optional, default
           }
         }
       }

--- a/src/asset-relocator.js
+++ b/src/asset-relocator.js
@@ -802,8 +802,12 @@ module.exports = async function (content, map) {
               return replacement;
             case 'directory':
               // do not emit asset directories lower than the package base itself
-              if (path.resolve(value).startsWith(pkgBase))
-                return emitAssetDirectory(path.resolve(value));
+              const resolved = path.resolve(value);
+              if (!pkgBase || resolved.startsWith(pkgBase))
+                return emitAssetDirectory(resolved);
+              else if (options.debugLog)
+                console.log('Skipping asset emission of ' + resolved + ' directory for ' + id + ' as it is outside the package base ' + pkgBase);
+
           }
         }
         staticChildNode = staticChildValue = undefined;

--- a/src/asset-relocator.js
+++ b/src/asset-relocator.js
@@ -198,7 +198,8 @@ module.exports = async function (content, map) {
     const name = assetState.assets[assetPath] ||
         (assetState.assets[assetPath] = getUniqueAssetName(outName, assetPath, assetState.assetNames));
 
-    // console.log('Emitting ' + assetPath + ' for module ' + id);
+    if (options.debugLog)
+      console.log('Emitting ' + assetPath + ' for static use in module ' + id);
     assetEmissionPromises = assetEmissionPromises.then(async () => {
       const [source, stats] = await Promise.all([
         new Promise((resolve, reject) =>
@@ -223,6 +224,8 @@ module.exports = async function (content, map) {
     return "__dirname + '/" + relAssetPath(this, options) + JSON.stringify(name).slice(1, -1) + "'";
   };
   const emitAssetDirectory = (assetDirPath) => {
+    if (options.debugLog)
+      console.log('Emitting directory ' + assetDirPath + ' for static use in module ' + id);
     const dirName = path.basename(assetDirPath);
     const name = assetState.assets[assetDirPath] || (assetState.assets[assetDirPath] = getUniqueAssetName(dirName, assetDirPath, assetState.assetNames));
     assetState.assets[assetDirPath] = name;
@@ -798,7 +801,9 @@ module.exports = async function (content, map) {
                 replacement = '__non_webpack_require__(' + replacement + ')';
               return replacement;
             case 'directory':
-              return emitAssetDirectory(path.resolve(value));
+              // do not emit asset directories lower than the package base itself
+              if (path.resolve(value).startsWith(pkgBase))
+                return emitAssetDirectory(path.resolve(value));
           }
         }
         staticChildNode = staticChildValue = undefined;

--- a/src/asset-relocator.js
+++ b/src/asset-relocator.js
@@ -801,7 +801,7 @@ module.exports = async function (content, map) {
                 replacement = '__non_webpack_require__(' + replacement + ')';
               return replacement;
             case 'directory':
-              // do not emit asset directories lower than the package base itself
+              // do not emit asset directories higher than the package base itself
               const resolved = path.resolve(value);
               if (!pkgBase || resolved.startsWith(pkgBase))
                 return emitAssetDirectory(resolved);

--- a/src/utils/sharedlib-emit.js
+++ b/src/utils/sharedlib-emit.js
@@ -16,7 +16,7 @@ switch (os.platform()) {
 }
 
 // helper for emitting the associated shared libraries when a binary is emitted
-module.exports = async function (pkgPath, assetState, assetBase, emitFile) {
+module.exports = async function (pkgPath, assetState, assetBase, emitFile, debugLog) {
   const files = await new Promise((resolve, reject) =>
     glob(pkgPath + sharedlibGlob, { ignore: 'node_modules/**/*' }, (err, files) => err ? reject(err) : resolve(files))
   );
@@ -38,6 +38,8 @@ module.exports = async function (pkgPath, assetState, assetBase, emitFile) {
     }
     else {
       assetState.assetPermissions[file.substr(pkgPath.length)] = stats.mode;
+      if (debugLog)
+        console.log('Emitting ' + file + ' for shared library support in ' + pkgPath);
       emitFile(assetBase + file.substr(pkgPath.length), source);
     }
   }));

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -46,7 +46,8 @@ for (const unitTest of fs.readdirSync(`${__dirname}/unit`)) {
             options: {
               existingAssetNames: ['existing.txt'],
               escapeNonAnalyzableRequires: true,
-              wrapperCompatibility: true
+              wrapperCompatibility: true,
+              debugLog: true
             }
           }]
         }],


### PR DESCRIPTION
This resolves https://github.com/zeit/ncc/issues/359, firstly implementing a `debugLog` option to determine why certain assets are emitted and secondly to fix the issue by restricting asset emission to the package boundary.

In theory this is a breaking change.