### PR TITLE
process.env analysis in require conditionals

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,8 @@ Any `.node` files included will also support binary relocation.
             existingAssetNames: []
             wrapperCompatibility: false, // optional, default
             escapeNonAnalyzableRequires: false, // optional, default
-
+            // build for process.env.NODE_ENV = 'production'
+            production: false, // optional, default
           }
         }
       }

--- a/src/asset-relocator.js
+++ b/src/asset-relocator.js
@@ -300,8 +300,12 @@ module.exports = async function (content, map) {
     },
     process: {
       shadowDepth: 0,
-      value: {
-        [UNKNOWN]: true   
+      value: {   
+        env: {
+          NODE_ENV: options.production ? 'production' : UNKNOWN,
+          [UNKNOWN]: true
+        },
+        [UNKNOWN]: true
       }
     }
   });

--- a/src/utils/static-eval.js
+++ b/src/utils/static-eval.js
@@ -200,8 +200,12 @@ module.exports = function (ast, vars = {}) {
         return;
       if (node.property.type === 'Identifier') {
         if (typeof obj.value === 'object' && obj.value !== null) {
-          if (node.property.name in obj.value)
-            return { value: obj.value[node.property.name] };
+          if (node.property.name in obj.value) {
+            const val = obj.value[node.property.name];
+            if (val === UNKNOWN)
+              return;
+            return { value: val };
+          }
           else if (obj.value[UNKNOWN])
             return;
         }

--- a/test/unit/process-env/a.js
+++ b/test/unit/process-env/a.js
@@ -1,0 +1,1 @@
+console.log('a');

--- a/test/unit/process-env/b.js
+++ b/test/unit/process-env/b.js
@@ -1,0 +1,1 @@
+console.log('b');

--- a/test/unit/process-env/input.js
+++ b/test/unit/process-env/input.js
@@ -1,0 +1,1 @@
+require(process.env.NODE_ENV === 'production' ? './a.js' : './b.js');

--- a/test/unit/process-env/output-coverage.js
+++ b/test/unit/process-env/output-coverage.js
@@ -89,18 +89,11 @@ module.exports =
 /* 0 */
 /***/ (function(module, exports, __webpack_require__) {
 
-__webpack_require__(process.env.NODE_ENV === 'production' ? 1 : 2);
+__webpack_require__(1);
 
 
 /***/ }),
 /* 1 */
-/***/ (function(module, exports) {
-
-console.log('a');
-
-
-/***/ }),
-/* 2 */
 /***/ (function(module, exports) {
 
 console.log('b');

--- a/test/unit/process-env/output-coverage.js
+++ b/test/unit/process-env/output-coverage.js
@@ -1,0 +1,110 @@
+module.exports =
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports, __webpack_require__) {
+
+__webpack_require__(process.env.NODE_ENV === 'production' ? 1 : 2);
+
+
+/***/ }),
+/* 1 */
+/***/ (function(module, exports) {
+
+console.log('a');
+
+
+/***/ }),
+/* 2 */
+/***/ (function(module, exports) {
+
+console.log('b');
+
+
+/***/ })
+/******/ ]);

--- a/test/unit/process-env/output.js
+++ b/test/unit/process-env/output.js
@@ -89,18 +89,11 @@ module.exports =
 /* 0 */
 /***/ (function(module, exports, __webpack_require__) {
 
-__webpack_require__(process.env.NODE_ENV === 'production' ? 1 : 2);
+__webpack_require__(1);
 
 
 /***/ }),
 /* 1 */
-/***/ (function(module, exports) {
-
-console.log('a');
-
-
-/***/ }),
-/* 2 */
 /***/ (function(module, exports) {
 
 console.log('b');

--- a/test/unit/process-env/output.js
+++ b/test/unit/process-env/output.js
@@ -1,0 +1,110 @@
+module.exports =
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports, __webpack_require__) {
+
+__webpack_require__(process.env.NODE_ENV === 'production' ? 1 : 2);
+
+
+/***/ }),
+/* 1 */
+/***/ (function(module, exports) {
+
+console.log('a');
+
+
+/***/ }),
+/* 2 */
+/***/ (function(module, exports) {
+
+console.log('b');
+
+
+/***/ })
+/******/ ]);


### PR DESCRIPTION
This was originally created to handle https://github.com/zeit/ncc/issues/358, but it would only work if we explicitly add the `FLUENTFFMPEG_COV: false` to the analysis here. I don't think we should treat all unknown process.env properties as falsy, which was the tempting way to do this, but that seems like it would break other things.

Will see if I can work on another approach for https://github.com/zeit/ncc/issues/358.