### PR TITLE
Fixup json import conditional failure

### DIFF
--- a/src/asset-relocator.js
+++ b/src/asset-relocator.js
@@ -369,7 +369,7 @@ module.exports = async function (content, map) {
 
   function requireWillFail (specifier) {
     try {
-      resolve.sync(specifier + '.js', { basedir: path.dirname(id) });
+      resolve.sync(specifier, { basedir: path.dirname(id) });
       return false;
     }
     catch (e) {

--- a/src/asset-relocator.js
+++ b/src/asset-relocator.js
@@ -20,6 +20,8 @@ const stage3 = require('acorn-stage3');
 const mergeSourceMaps = require('./utils/merge-source-maps');
 acorn = acorn.Parser.extend(stage3);
 
+const extensions = ['.js', '.json', '.node'];
+
 const staticPath = Object.assign({ default: path }, path);
 const staticFs = { default: { existsSync }, existsSync };
 const { UNKNOWN } = evaluate;
@@ -71,11 +73,11 @@ function getAssetState (options, compilation) {
 
 function getEntryId (compilation) {
   if (compilation.options && typeof compilation.options.entry === 'string') {
-    return resolve.sync(compilation.options.entry);
+    return resolve.sync(compilation.options.entry, { extensions });
   }
   if (compilation.entries && compilation.entries.length) {
     try {
-      return resolve.sync(compilation.entries[0].name || compilation.entries[0].resource, { basedir: path.dirname(compilation.entries[0].context) });
+      return resolve.sync(compilation.entries[0].name || compilation.entries[0].resource, { basedir: path.dirname(compilation.entries[0].context), extensions });
     }
     catch (e) {
       return;
@@ -86,7 +88,7 @@ function getEntryId (compilation) {
     for (entry of entryMap.values()) {
       if (entry.length) {
         try {
-          return resolve.sync(entry[0].request, { basedir: path.dirname(entry[0].context) });
+          return resolve.sync(entry[0].request, { basedir: path.dirname(entry[0].context), extensions });
         }
         catch (e) {
           return;
@@ -305,7 +307,7 @@ module.exports = async function (content, map) {
       shadowDepth: 0,
       value: {   
         env: {
-          NODE_ENV: options.production ? 'production' : UNKNOWN,
+          NODE_ENV: typeof options.production === 'boolean' ? (options.production ? 'production' : 'dev') : UNKNOWN,
           [UNKNOWN]: true
         },
         [UNKNOWN]: true
@@ -369,7 +371,7 @@ module.exports = async function (content, map) {
 
   function requireWillFail (specifier) {
     try {
-      resolve.sync(specifier, { basedir: path.dirname(id) });
+      resolve.sync(specifier, { basedir: path.dirname(id), extensions });
       return false;
     }
     catch (e) {
@@ -563,14 +565,28 @@ module.exports = async function (content, map) {
               }
               else {
                 // branched require
+                const conditionValue = computeStaticValue(computed.test);
+                // inline the known branch if possible
+                if (conditionValue && 'value' in conditionValue) {
+                  if (conditionValue) {
+                    transformed = true;
+                    magicString.overwrite(expression.start, expression.end, JSON.stringify(computed.then));
+                    return this.skip();
+                  }
+                  else {
+                    transformed = true;
+                    magicString.overwrite(expression.start, expression.end, JSON.stringify(computed.else));
+                    return this.skip();
+                  }
+                }
                 // if one branch is a not found, Webpack fails the whole build
                 // so detect any not found now and inline the found branch
-                if (typeof computed.then === 'string' && requireWillFail(computed.then)) {
+                else if (typeof computed.then === 'string' && requireWillFail(computed.then)) {
                   transformed = true;
                   magicString.overwrite(expression.start, expression.end, JSON.stringify(computed.else));
                   return this.skip();
                 }
-                if (typeof computed.else === 'string' && requireWillFail(computed.else)) {
+                else if (typeof computed.else === 'string' && requireWillFail(computed.else)) {
                   transformed = true;
                   magicString.overwrite(expression.start, expression.end, JSON.stringify(computed.then));
                   return this.skip();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -47,7 +47,8 @@ for (const unitTest of fs.readdirSync(`${__dirname}/unit`)) {
               existingAssetNames: ['existing.txt'],
               escapeNonAnalyzableRequires: true,
               wrapperCompatibility: true,
-              debugLog: true
+              debugLog: true,
+              production: true
             }
           }]
         }],

--- a/test/unit/process-env/output-coverage.js
+++ b/test/unit/process-env/output-coverage.js
@@ -96,7 +96,7 @@ __webpack_require__(1);
 /* 1 */
 /***/ (function(module, exports) {
 
-console.log('b');
+console.log('a');
 
 
 /***/ })

--- a/test/unit/process-env/output.js
+++ b/test/unit/process-env/output.js
@@ -96,7 +96,7 @@ __webpack_require__(1);
 /* 1 */
 /***/ (function(module, exports) {
 
-console.log('b');
+console.log('a');
 
 
 /***/ })


### PR DESCRIPTION
This fixes the regression on the ncc upgrade path for juggling-db.

In the conditional failure handling I was able to remove the explicit Node.js version inlining, but to fully support juggling-db this requires supporting `.json` files in conditional failure paths.