### PR TITLE
Include assetBase in symlinks handling

### DIFF
--- a/src/utils/sharedlib-emit.js
+++ b/src/utils/sharedlib-emit.js
@@ -34,7 +34,7 @@ module.exports = async function (pkgPath, assetState, assetBase, emitFile, debug
         fs.readlink(file, (err, path) => err ? reject(err) : resolve(path));
       });
       const baseDir = path.dirname(file);
-      assetState.assetSymlinks[file.substr(pkgPath.length + 1)] = path.relative(baseDir, path.resolve(baseDir, symlink));
+      assetState.assetSymlinks[assetBase + file.substr(pkgPath.length + 1)] = path.relative(baseDir, path.resolve(baseDir, symlink));
     }
     else {
       assetState.assetPermissions[file.substr(pkgPath.length)] = stats.mode;


### PR DESCRIPTION
This fixes a bug in the handling of symlinks output with an assetBase, where the assetBase was not taken into account for the symlink path.

This gets the tests on https://github.com/zeit/ncc/pull/410 to pass.