### PR TITLE
Known bindings regression with 'module' tracking

### DIFF
--- a/src/asset-relocator.js
+++ b/src/asset-relocator.js
@@ -501,10 +501,6 @@ module.exports = async function (content, map) {
       }
     };
     knownBindings.require.value.resolve[TRIGGER] = true;
-    knownBindings.module = {
-      shadowDepth: 0,
-      value: UNKNOWN
-    };
   }
 
   let wildcardBlocks = [];
@@ -764,7 +760,7 @@ module.exports = async function (content, map) {
       else if (!isESM && node.type === 'MemberExpression' &&
                node.object.type === 'Identifier' &&
                node.object.name === 'module' &&
-               knownBindings.module.shadowDepth === 0 &&
+               'module' in knownBindings === false &&
                node.property.type === 'Identifier' &&
                !node.computed &&
                node.property.name === 'require') {

--- a/test/unit/module-require/input.js
+++ b/test/unit/module-require/input.js
@@ -1,3 +1,6 @@
+function x (module) {
+}
+
 exports.asdf = 'asdf';
 console.log(module.require('./input.js'));
 

--- a/test/unit/module-require/output-coverage.js
+++ b/test/unit/module-require/output-coverage.js
@@ -89,11 +89,15 @@ module.exports =
 /* 0 */
 /***/ (function(module, exports, __webpack_require__) {
 
+function x (module) {
+}
+
 exports.asdf = 'asdf';
 console.log(__webpack_require__(0));
 
 if (true)
   console.log("yes");
+
 
 /***/ })
 /******/ ]);

--- a/test/unit/module-require/output.js
+++ b/test/unit/module-require/output.js
@@ -89,11 +89,15 @@ module.exports =
 /* 0 */
 /***/ (function(module, exports, __webpack_require__) {
 
+function x (module) {
+}
+
 exports.asdf = 'asdf';
 console.log(__webpack_require__(0));
 
 if (true)
   console.log("yes");
+
 
 /***/ })
 /******/ ]);


### PR DESCRIPTION
The known bindings handling for `'module'` wasn't done quite right, leading to a bug on the ncc build.

This corrects that with the case that was causing the failure in the unit test.