### PR TITLE
Use webpack public path in asset emission

### DIFF
--- a/test/project-chunking/expected.js
+++ b/test/project-chunking/expected.js
@@ -4,6 +4,6 @@ const fs = require('fs');
 expect(output.length).toBe(18);
 
 // check relative asset references worked out
-expect(fs.readFileSync(__dirname + "/dist/modules/main.js").toString()).toContain(`"/../asset`);
-expect(fs.readFileSync(__dirname + "/dist/modules/chunk.js").toString()).toContain(`"/../asset`);
-expect(fs.readFileSync(__dirname + "/dist/modules/chunks/2.js").toString()).toContain(`"/../../asset`);
+expect(fs.readFileSync(__dirname + "/dist/modules/main.js").toString()).toContain(`p+"/asset`);
+expect(fs.readFileSync(__dirname + "/dist/modules/chunk.js").toString()).toContain(`p+"/asset`);
+expect(fs.readFileSync(__dirname + "/dist/modules/chunks/2.js").toString()).toContain(`p+"/asset`);

--- a/test/unit/amd-disable/output-coverage.js
+++ b/test/unit/amd-disable/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/amd-disable/output.js
+++ b/test/unit/amd-disable/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/array-emission/output-coverage.js
+++ b/test/unit/array-emission/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -90,16 +91,15 @@ module.exports =
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-/* WEBPACK VAR INJECTION */(function(__dirname) {
+
 
 const fs = __webpack_require__(1);
 
 const REPORT_JAVASCRIPT = [
-  fs.readFileSync(__dirname + '/util.js', 'utf8'),
-  fs.readFileSync(__dirname + '/dom.js', 'utf8'),
+  fs.readFileSync(__webpack_require__.p + '/util.js', 'utf8'),
+  fs.readFileSync(__webpack_require__.p + '/dom.js', 'utf8'),
 ].join(';\n');
 
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
 
 /***/ }),
 /* 1 */

--- a/test/unit/array-emission/output.js
+++ b/test/unit/array-emission/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -90,16 +91,15 @@ module.exports =
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-/* WEBPACK VAR INJECTION */(function(__dirname) {
+
 
 const fs = __webpack_require__(1);
 
 const REPORT_JAVASCRIPT = [
-  fs.readFileSync(__dirname + '/util.js', 'utf8'),
-  fs.readFileSync(__dirname + '/dom.js', 'utf8'),
+  fs.readFileSync(__webpack_require__.p + '/util.js', 'utf8'),
+  fs.readFileSync(__webpack_require__.p + '/dom.js', 'utf8'),
 ].join(';\n');
 
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
 
 /***/ }),
 /* 1 */

--- a/test/unit/array-holes/output-coverage.js
+++ b/test/unit/array-holes/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/array-holes/output.js
+++ b/test/unit/array-holes/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/asset-conditional/output-coverage.js
+++ b/test/unit/asset-conditional/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -89,9 +90,8 @@ module.exports =
 /* 0 */
 /***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(__dirname) {const path = __webpack_require__(1);
-let moduleJsPath = isHarmony ? __dirname + '/asset1.txt' : __dirname + '/asset2.txt';
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
+const path = __webpack_require__(1);
+let moduleJsPath = isHarmony ? __webpack_require__.p + '/asset1.txt' : __webpack_require__.p + '/asset2.txt';
 
 /***/ }),
 /* 1 */

--- a/test/unit/asset-conditional/output.js
+++ b/test/unit/asset-conditional/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -89,9 +90,8 @@ module.exports =
 /* 0 */
 /***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(__dirname) {const path = __webpack_require__(1);
-let moduleJsPath = isHarmony ? __dirname + '/asset1.txt' : __dirname + '/asset2.txt';
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
+const path = __webpack_require__(1);
+let moduleJsPath = isHarmony ? __webpack_require__.p + '/asset1.txt' : __webpack_require__.p + '/asset2.txt';
 
 /***/ }),
 /* 1 */

--- a/test/unit/asset-fs-existing-asset-name/output-coverage.js
+++ b/test/unit/asset-fs-existing-asset-name/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -89,10 +90,9 @@ module.exports =
 /* 0 */
 /***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(__dirname) {const fs = __webpack_require__(1);
-console.log(fs.readFileSync(__dirname + '/existing1.txt'));
+const fs = __webpack_require__(1);
+console.log(fs.readFileSync(__webpack_require__.p + '/existing1.txt'));
 
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
 
 /***/ }),
 /* 1 */

--- a/test/unit/asset-fs-existing-asset-name/output.js
+++ b/test/unit/asset-fs-existing-asset-name/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -89,10 +90,9 @@ module.exports =
 /* 0 */
 /***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(__dirname) {const fs = __webpack_require__(1);
-console.log(fs.readFileSync(__dirname + '/existing1.txt'));
+const fs = __webpack_require__(1);
+console.log(fs.readFileSync(__webpack_require__.p + '/existing1.txt'));
 
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
 
 /***/ }),
 /* 1 */

--- a/test/unit/asset-fs-inline-assign/output-coverage.js
+++ b/test/unit/asset-fs-inline-assign/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -92,7 +93,7 @@ module.exports =
 /* WEBPACK VAR INJECTION */(function(__dirname) {const fs = __webpack_require__(1);
 const { join } = __webpack_require__(2);
 
-console.log(fs.readFileSync(__dirname + '/asset.txt', 'utf8'));
+console.log(fs.readFileSync(__webpack_require__.p + '/asset.txt', 'utf8'));
 
 (function () {
   var join = () => 'nope';

--- a/test/unit/asset-fs-inline-assign/output.js
+++ b/test/unit/asset-fs-inline-assign/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -92,7 +93,7 @@ module.exports =
 /* WEBPACK VAR INJECTION */(function(__dirname) {const fs = __webpack_require__(1);
 const { join } = __webpack_require__(2);
 
-console.log(fs.readFileSync(__dirname + '/asset.txt', 'utf8'));
+console.log(fs.readFileSync(__webpack_require__.p + '/asset.txt', 'utf8'));
 
 (function () {
   var join = () => 'nope';

--- a/test/unit/asset-fs-inline-path-enc-es-2/output-coverage.js
+++ b/test/unit/asset-fs-inline-path-enc-es-2/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -97,15 +98,14 @@ module.exports = require("fs");
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* WEBPACK VAR INJECTION */(function(__dirname) {/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(0);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(0);
 /* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(2);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_1__);
 
 
 
-console.log(fs__WEBPACK_IMPORTED_MODULE_0___default.a.readFileSync(__dirname + '/asset.txt', 'utf8'));
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
+console.log(fs__WEBPACK_IMPORTED_MODULE_0___default.a.readFileSync(__webpack_require__.p + '/asset.txt', 'utf8'));
 
 /***/ }),
 /* 2 */

--- a/test/unit/asset-fs-inline-path-enc-es-2/output.js
+++ b/test/unit/asset-fs-inline-path-enc-es-2/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -97,15 +98,14 @@ module.exports = require("fs");
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* WEBPACK VAR INJECTION */(function(__dirname) {/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(0);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(0);
 /* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(2);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_1__);
 
 
 
-console.log(fs__WEBPACK_IMPORTED_MODULE_0___default.a.readFileSync(__dirname + '/asset.txt', 'utf8'));
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
+console.log(fs__WEBPACK_IMPORTED_MODULE_0___default.a.readFileSync(__webpack_require__.p + '/asset.txt', 'utf8'));
 
 /***/ }),
 /* 2 */

--- a/test/unit/asset-fs-inline-path-enc-es-3/output-coverage.js
+++ b/test/unit/asset-fs-inline-path-enc-es-3/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -97,15 +98,14 @@ module.exports = require("fs");
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* WEBPACK VAR INJECTION */(function(__dirname) {/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(0);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(0);
 /* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(2);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_1__);
 
 
 
-console.log(fs__WEBPACK_IMPORTED_MODULE_0___default.a.readFileSync(__dirname + '/asset.txt', 'utf8'));
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
+console.log(fs__WEBPACK_IMPORTED_MODULE_0___default.a.readFileSync(__webpack_require__.p + '/asset.txt', 'utf8'));
 
 /***/ }),
 /* 2 */

--- a/test/unit/asset-fs-inline-path-enc-es-3/output.js
+++ b/test/unit/asset-fs-inline-path-enc-es-3/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -97,15 +98,14 @@ module.exports = require("fs");
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* WEBPACK VAR INJECTION */(function(__dirname) {/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(0);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(0);
 /* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(2);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_1__);
 
 
 
-console.log(fs__WEBPACK_IMPORTED_MODULE_0___default.a.readFileSync(__dirname + '/asset.txt', 'utf8'));
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
+console.log(fs__WEBPACK_IMPORTED_MODULE_0___default.a.readFileSync(__webpack_require__.p + '/asset.txt', 'utf8'));
 
 /***/ }),
 /* 2 */

--- a/test/unit/asset-fs-inline-path-enc-es-4/output-coverage.js
+++ b/test/unit/asset-fs-inline-path-enc-es-4/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -103,7 +104,7 @@ module.exports = require("path");
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* WEBPACK VAR INJECTION */(function(__dirname) {/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(0);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(0);
 /* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(1);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_1__);
@@ -112,8 +113,7 @@ __webpack_require__.r(__webpack_exports__);
 
 const join = path__WEBPACK_IMPORTED_MODULE_1__["join"];
 
-console.log(fs__WEBPACK_IMPORTED_MODULE_0___default.a.readFileSync(__dirname + '/asset.txt', 'utf8'));
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
+console.log(fs__WEBPACK_IMPORTED_MODULE_0___default.a.readFileSync(__webpack_require__.p + '/asset.txt', 'utf8'));
 
 /***/ })
 /******/ ]);

--- a/test/unit/asset-fs-inline-path-enc-es-4/output.js
+++ b/test/unit/asset-fs-inline-path-enc-es-4/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -103,7 +104,7 @@ module.exports = require("path");
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* WEBPACK VAR INJECTION */(function(__dirname) {/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(0);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(0);
 /* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(1);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_1__);
@@ -112,8 +113,7 @@ __webpack_require__.r(__webpack_exports__);
 
 const join = path__WEBPACK_IMPORTED_MODULE_1__["join"];
 
-console.log(fs__WEBPACK_IMPORTED_MODULE_0___default.a.readFileSync(__dirname + '/asset.txt', 'utf8'));
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
+console.log(fs__WEBPACK_IMPORTED_MODULE_0___default.a.readFileSync(__webpack_require__.p + '/asset.txt', 'utf8'));
 
 /***/ })
 /******/ ]);

--- a/test/unit/asset-fs-inline-path-enc-es-5/output-coverage.js
+++ b/test/unit/asset-fs-inline-path-enc-es-5/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -97,16 +98,15 @@ module.exports = require("fs");
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* WEBPACK VAR INJECTION */(function(__dirname) {/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(0);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(0);
 /* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(2);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_1__);
 
 
 
-console.log(fs__WEBPACK_IMPORTED_MODULE_0___default.a.readFileSync(__dirname + '/asset.txt', 'utf8'));
+console.log(fs__WEBPACK_IMPORTED_MODULE_0___default.a.readFileSync(__webpack_require__.p + '/asset.txt', 'utf8'));
 
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
 
 /***/ }),
 /* 2 */

--- a/test/unit/asset-fs-inline-path-enc-es-5/output.js
+++ b/test/unit/asset-fs-inline-path-enc-es-5/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -97,16 +98,15 @@ module.exports = require("fs");
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* WEBPACK VAR INJECTION */(function(__dirname) {/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(0);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(0);
 /* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(2);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_1__);
 
 
 
-console.log(fs__WEBPACK_IMPORTED_MODULE_0___default.a.readFileSync(__dirname + '/asset.txt', 'utf8'));
+console.log(fs__WEBPACK_IMPORTED_MODULE_0___default.a.readFileSync(__webpack_require__.p + '/asset.txt', 'utf8'));
 
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
 
 /***/ }),
 /* 2 */

--- a/test/unit/asset-fs-inline-path-enc-es/output-coverage.js
+++ b/test/unit/asset-fs-inline-path-enc-es/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -97,15 +98,14 @@ module.exports = require("fs");
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* WEBPACK VAR INJECTION */(function(__dirname) {/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(0);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(0);
 /* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(2);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_1__);
 
 
 
-console.log(fs__WEBPACK_IMPORTED_MODULE_0___default.a.readFileSync(__dirname + '/asset.txt', 'utf8'));
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
+console.log(fs__WEBPACK_IMPORTED_MODULE_0___default.a.readFileSync(__webpack_require__.p + '/asset.txt', 'utf8'));
 
 /***/ }),
 /* 2 */

--- a/test/unit/asset-fs-inline-path-enc-es/output.js
+++ b/test/unit/asset-fs-inline-path-enc-es/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -97,15 +98,14 @@ module.exports = require("fs");
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* WEBPACK VAR INJECTION */(function(__dirname) {/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(0);
+/* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(0);
 /* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(2);
 /* harmony import */ var path__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(path__WEBPACK_IMPORTED_MODULE_1__);
 
 
 
-console.log(fs__WEBPACK_IMPORTED_MODULE_0___default.a.readFileSync(__dirname + '/asset.txt', 'utf8'));
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
+console.log(fs__WEBPACK_IMPORTED_MODULE_0___default.a.readFileSync(__webpack_require__.p + '/asset.txt', 'utf8'));
 
 /***/ }),
 /* 2 */

--- a/test/unit/asset-fs-inline-path-enc/output-coverage.js
+++ b/test/unit/asset-fs-inline-path-enc/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -89,10 +90,9 @@ module.exports =
 /* 0 */
 /***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(__dirname) {const fs = __webpack_require__(1);
+const fs = __webpack_require__(1);
 const { join } = __webpack_require__(2);
-console.log(fs.readFileSync(__dirname + '/asset.txt', 'utf8'));
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
+console.log(fs.readFileSync(__webpack_require__.p + '/asset.txt', 'utf8'));
 
 /***/ }),
 /* 1 */

--- a/test/unit/asset-fs-inline-path-enc/output.js
+++ b/test/unit/asset-fs-inline-path-enc/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -89,10 +90,9 @@ module.exports =
 /* 0 */
 /***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(__dirname) {const fs = __webpack_require__(1);
+const fs = __webpack_require__(1);
 const { join } = __webpack_require__(2);
-console.log(fs.readFileSync(__dirname + '/asset.txt', 'utf8'));
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
+console.log(fs.readFileSync(__webpack_require__.p + '/asset.txt', 'utf8'));
 
 /***/ }),
 /* 1 */

--- a/test/unit/asset-fs-inline-path-shadow/output-coverage.js
+++ b/test/unit/asset-fs-inline-path-shadow/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -92,7 +93,7 @@ module.exports =
 /* WEBPACK VAR INJECTION */(function(__dirname) {const fs = __webpack_require__(1);
 const { join } = __webpack_require__(2);
 
-console.log(fs.readFileSync(__dirname + '/asset.txt', 'utf8'));
+console.log(fs.readFileSync(__webpack_require__.p + '/asset.txt', 'utf8'));
 
 (function () {
   var join = () => 'nope';

--- a/test/unit/asset-fs-inline-path-shadow/output.js
+++ b/test/unit/asset-fs-inline-path-shadow/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -92,7 +93,7 @@ module.exports =
 /* WEBPACK VAR INJECTION */(function(__dirname) {const fs = __webpack_require__(1);
 const { join } = __webpack_require__(2);
 
-console.log(fs.readFileSync(__dirname + '/asset.txt', 'utf8'));
+console.log(fs.readFileSync(__webpack_require__.p + '/asset.txt', 'utf8'));
 
 (function () {
   var join = () => 'nope';

--- a/test/unit/asset-fs-inline-tpl/output-coverage.js
+++ b/test/unit/asset-fs-inline-tpl/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -89,9 +90,8 @@ module.exports =
 /* 0 */
 /***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(__dirname) {const fs = __webpack_require__(1);
-console.log(fs.readFileSync(__dirname + '/asset.txt'));
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
+const fs = __webpack_require__(1);
+console.log(fs.readFileSync(__webpack_require__.p + '/asset.txt'));
 
 /***/ }),
 /* 1 */

--- a/test/unit/asset-fs-inline-tpl/output.js
+++ b/test/unit/asset-fs-inline-tpl/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -89,9 +90,8 @@ module.exports =
 /* 0 */
 /***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(__dirname) {const fs = __webpack_require__(1);
-console.log(fs.readFileSync(__dirname + '/asset.txt'));
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
+const fs = __webpack_require__(1);
+console.log(fs.readFileSync(__webpack_require__.p + '/asset.txt'));
 
 /***/ }),
 /* 1 */

--- a/test/unit/asset-fs-inlining-multi/output-coverage.js
+++ b/test/unit/asset-fs-inlining-multi/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -89,10 +90,9 @@ module.exports =
 /* 0 */
 /***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(__dirname) {const fs = __webpack_require__(1);
-console.log(fs.readFileSync(__dirname + '/asset.txt'));
-console.log(fs.readFileSync(__dirname + '/asset1.txt'));
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
+const fs = __webpack_require__(1);
+console.log(fs.readFileSync(__webpack_require__.p + '/asset.txt'));
+console.log(fs.readFileSync(__webpack_require__.p + '/asset1.txt'));
 
 /***/ }),
 /* 1 */

--- a/test/unit/asset-fs-inlining-multi/output.js
+++ b/test/unit/asset-fs-inlining-multi/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -89,10 +90,9 @@ module.exports =
 /* 0 */
 /***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(__dirname) {const fs = __webpack_require__(1);
-console.log(fs.readFileSync(__dirname + '/asset.txt'));
-console.log(fs.readFileSync(__dirname + '/asset1.txt'));
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
+const fs = __webpack_require__(1);
+console.log(fs.readFileSync(__webpack_require__.p + '/asset.txt'));
+console.log(fs.readFileSync(__webpack_require__.p + '/asset1.txt'));
 
 /***/ }),
 /* 1 */

--- a/test/unit/asset-fs-inlining/output-coverage.js
+++ b/test/unit/asset-fs-inlining/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -89,9 +90,8 @@ module.exports =
 /* 0 */
 /***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(__dirname) {const fs = __webpack_require__(1);
-console.log(fs.readFileSync(__dirname + '/asset.txt'));
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
+const fs = __webpack_require__(1);
+console.log(fs.readFileSync(__webpack_require__.p + '/asset.txt'));
 
 /***/ }),
 /* 1 */

--- a/test/unit/asset-fs-inlining/output.js
+++ b/test/unit/asset-fs-inlining/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -89,9 +90,8 @@ module.exports =
 /* 0 */
 /***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(__dirname) {const fs = __webpack_require__(1);
-console.log(fs.readFileSync(__dirname + '/asset.txt'));
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
+const fs = __webpack_require__(1);
+console.log(fs.readFileSync(__webpack_require__.p + '/asset.txt'));
 
 /***/ }),
 /* 1 */

--- a/test/unit/asset-fs-logical/output-coverage.js
+++ b/test/unit/asset-fs-logical/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -89,10 +90,9 @@ module.exports =
 /* 0 */
 /***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(__dirname) {const fs = __webpack_require__(1);
-console.log(fs.readFileSync(unknown ? __dirname + '/asset1.txt' : __dirname + '/asset2.txt'));
+const fs = __webpack_require__(1);
+console.log(fs.readFileSync(unknown ? __webpack_require__.p + '/asset1.txt' : __webpack_require__.p + '/asset2.txt'));
 
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
 
 /***/ }),
 /* 1 */

--- a/test/unit/asset-fs-logical/output.js
+++ b/test/unit/asset-fs-logical/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -89,10 +90,9 @@ module.exports =
 /* 0 */
 /***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(__dirname) {const fs = __webpack_require__(1);
-console.log(fs.readFileSync(unknown ? __dirname + '/asset1.txt' : __dirname + '/asset2.txt'));
+const fs = __webpack_require__(1);
+console.log(fs.readFileSync(unknown ? __webpack_require__.p + '/asset1.txt' : __webpack_require__.p + '/asset2.txt'));
 
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
 
 /***/ }),
 /* 1 */

--- a/test/unit/asset-node-require/output-coverage.js
+++ b/test/unit/asset-node-require/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -94,9 +95,9 @@ __webpack_require__(1);
 
 /***/ }),
 /* 1 */
-/***/ (function(module, exports) {
+/***/ (function(module, exports, __webpack_require__) {
 
-module.exports = require("./mock.node")
+module.exports = require(__webpack_require__.p + "/mock.node")
 
 /***/ })
 /******/ ]);

--- a/test/unit/asset-node-require/output.js
+++ b/test/unit/asset-node-require/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -94,9 +95,9 @@ __webpack_require__(1);
 
 /***/ }),
 /* 1 */
-/***/ (function(module, exports) {
+/***/ (function(module, exports, __webpack_require__) {
 
-module.exports = require("./mock.node")
+module.exports = require(__webpack_require__.p + "/mock.node")
 
 /***/ })
 /******/ ]);

--- a/test/unit/asset-package-json/output-coverage.js
+++ b/test/unit/asset-package-json/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -89,11 +90,10 @@ module.exports =
 /* 0 */
 /***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(__dirname) {const path = __webpack_require__(1);
+const path = __webpack_require__(1);
 
 var binding_path =
-    binary.find(__dirname + '/package.json');
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
+    binary.find(__webpack_require__.p + '/package.json');
 
 /***/ }),
 /* 1 */

--- a/test/unit/asset-package-json/output.js
+++ b/test/unit/asset-package-json/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -89,11 +90,10 @@ module.exports =
 /* 0 */
 /***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(__dirname) {const path = __webpack_require__(1);
+const path = __webpack_require__(1);
 
 var binding_path =
-    binary.find(__dirname + '/package.json');
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
+    binary.find(__webpack_require__.p + '/package.json');
 
 /***/ }),
 /* 1 */

--- a/test/unit/bindings-failure/output-coverage.js
+++ b/test/unit/bindings-failure/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/bindings-failure/output.js
+++ b/test/unit/bindings-failure/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/browserify-uglify/output-coverage.js
+++ b/test/unit/browserify-uglify/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/browserify-uglify/output.js
+++ b/test/unit/browserify-uglify/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/browserify/output-coverage.js
+++ b/test/unit/browserify/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/browserify/output.js
+++ b/test/unit/browserify/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/dirname-len/output-coverage.js
+++ b/test/unit/dirname-len/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/dirname-len/output.js
+++ b/test/unit/dirname-len/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/esm/output-coverage.js
+++ b/test/unit/esm/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/esm/output.js
+++ b/test/unit/esm/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/express-template-engine/output-coverage.js
+++ b/test/unit/express-template-engine/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/express-template-engine/output.js
+++ b/test/unit/express-template-engine/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/express-template/output-coverage.js
+++ b/test/unit/express-template/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/express-template/output.js
+++ b/test/unit/express-template/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/ffmpeg-installer/output-coverage.js
+++ b/test/unit/ffmpeg-installer/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -115,7 +116,7 @@ var npm3Path = path.resolve(__dirname, '..', platform);
 var npm2Path = path.resolve(__dirname, '.', platform);
 
 var npm3Binary = path.join(npm3Path, binary);
-var npm2Binary = __dirname + '/ffmpeg.exe';
+var npm2Binary = __webpack_require__.p + '/ffmpeg.exe';
 
 var npm3Package = path.join(npm3Path, 'package.json');
 var npm2Package = path.join(npm2Path, 'package.json');
@@ -124,8 +125,8 @@ var ffmpegPath, packageJson;
 
 if (verifyFile(npm3Binary)) {
     ffmpegPath = npm3Binary;
-} else if (verifyFile(__dirname + '/ffmpeg.exe')) {
-    ffmpegPath = __dirname + '/ffmpeg.exe';
+} else if (verifyFile(__webpack_require__.p + '/ffmpeg.exe')) {
+    ffmpegPath = __webpack_require__.p + '/ffmpeg.exe';
 } else {
     throw 'Could not find ffmpeg executable, tried "' + npm3Binary + '" and "' + npm2Binary + '"';
 }
@@ -134,7 +135,7 @@ var version = packageJson.ffmpeg || packageJson.version;
 var url = packageJson.homepage;
 
 module.exports = {
-    path: __dirname + '/ffmpeg.exe',
+    path: __webpack_require__.p + '/ffmpeg.exe',
     version: version,
     url: url
 };

--- a/test/unit/ffmpeg-installer/output.js
+++ b/test/unit/ffmpeg-installer/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -115,7 +116,7 @@ var npm3Path = path.resolve(__dirname, '..', platform);
 var npm2Path = path.resolve(__dirname, '.', platform);
 
 var npm3Binary = path.join(npm3Path, binary);
-var npm2Binary = __dirname + '/ffmpeg.exe';
+var npm2Binary = __webpack_require__.p + '/ffmpeg.exe';
 
 var npm3Package = path.join(npm3Path, 'package.json');
 var npm2Package = path.join(npm2Path, 'package.json');
@@ -124,8 +125,8 @@ var ffmpegPath, packageJson;
 
 if (verifyFile(npm3Binary)) {
     ffmpegPath = npm3Binary;
-} else if (verifyFile(__dirname + '/ffmpeg.exe')) {
-    ffmpegPath = __dirname + '/ffmpeg.exe';
+} else if (verifyFile(__webpack_require__.p + '/ffmpeg.exe')) {
+    ffmpegPath = __webpack_require__.p + '/ffmpeg.exe';
 } else {
     throw 'Could not find ffmpeg executable, tried "' + npm3Binary + '" and "' + npm2Binary + '"';
 }
@@ -134,7 +135,7 @@ var version = packageJson.ffmpeg || packageJson.version;
 var url = packageJson.homepage;
 
 module.exports = {
-    path: __dirname + '/ffmpeg.exe',
+    path: __webpack_require__.p + '/ffmpeg.exe',
     version: version,
     url: url
 };

--- a/test/unit/fs-emission/output-coverage.js
+++ b/test/unit/fs-emission/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -93,11 +94,11 @@ module.exports =
 
 fs.readFile('./asset1.txt')
 
-fs.readFile(__dirname + '/asset2.txt')
+fs.readFile(__webpack_require__.p + '/asset2.txt')
 
 const _basePath = __dirname;
 const asset3 = 'asset3.txt';
-fs.readFileSync(__dirname + '/asset3.txt', 'utf8');
+fs.readFileSync(__webpack_require__.p + '/asset3.txt', 'utf8');
 
 /* WEBPACK VAR INJECTION */}.call(this, "/"))
 

--- a/test/unit/fs-emission/output.js
+++ b/test/unit/fs-emission/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -93,11 +94,11 @@ module.exports =
 
 fs.readFile('./asset1.txt')
 
-fs.readFile(__dirname + '/asset2.txt')
+fs.readFile(__webpack_require__.p + '/asset2.txt')
 
 const _basePath = __dirname;
 const asset3 = 'asset3.txt';
-fs.readFileSync(__dirname + '/asset3.txt', 'utf8');
+fs.readFileSync(__webpack_require__.p + '/asset3.txt', 'utf8');
 
 /* WEBPACK VAR INJECTION */}.call(this, "/"))
 

--- a/test/unit/google-gax/output-coverage.js
+++ b/test/unit/google-gax/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -87,11 +88,10 @@ module.exports =
 /************************************************************************/
 /******/ ([
 /* 0 */
-/***/ (function(module, exports) {
+/***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(__dirname) {const googleProtoFilesDir = __dirname + '/google-gax';
+const googleProtoFilesDir = __webpack_require__.p + '/google-gax';
 
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
 
 /***/ })
 /******/ ]);

--- a/test/unit/google-gax/output.js
+++ b/test/unit/google-gax/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -87,11 +88,10 @@ module.exports =
 /************************************************************************/
 /******/ ([
 /* 0 */
-/***/ (function(module, exports) {
+/***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(__dirname) {const googleProtoFilesDir = __dirname + '/google-gax';
+const googleProtoFilesDir = __webpack_require__.p + '/google-gax';
 
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
 
 /***/ })
 /******/ ]);

--- a/test/unit/google-gax2/output-coverage.js
+++ b/test/unit/google-gax2/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -87,11 +88,10 @@ module.exports =
 /************************************************************************/
 /******/ ([
 /* 0 */
-/***/ (function(module, exports) {
+/***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(__dirname) {var googleProtoFilesDir = __dirname + '/google-gax2';
+var googleProtoFilesDir = __webpack_require__.p + '/google-gax2';
 
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
 
 /***/ })
 /******/ ]);

--- a/test/unit/google-gax2/output.js
+++ b/test/unit/google-gax2/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -87,11 +88,10 @@ module.exports =
 /************************************************************************/
 /******/ ([
 /* 0 */
-/***/ (function(module, exports) {
+/***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(__dirname) {var googleProtoFilesDir = __dirname + '/google-gax2';
+var googleProtoFilesDir = __webpack_require__.p + '/google-gax2';
 
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
 
 /***/ })
 /******/ ]);

--- a/test/unit/main-equal/output-coverage.js
+++ b/test/unit/main-equal/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/main-equal/output.js
+++ b/test/unit/main-equal/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/module-require/output-coverage.js
+++ b/test/unit/module-require/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/module-require/output.js
+++ b/test/unit/module-require/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/mongoose/output-coverage.js
+++ b/test/unit/mongoose/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/mongoose/output.js
+++ b/test/unit/mongoose/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/non-analyzable-requires/output-coverage.js
+++ b/test/unit/non-analyzable-requires/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/non-analyzable-requires/output.js
+++ b/test/unit/non-analyzable-requires/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/null-destructure/output-coverage.js
+++ b/test/unit/null-destructure/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/null-destructure/output.js
+++ b/test/unit/null-destructure/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/oracledb/output-coverage.js
+++ b/test/unit/oracledb/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/oracledb/output.js
+++ b/test/unit/oracledb/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/path-sep/output-coverage.js
+++ b/test/unit/path-sep/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -89,12 +90,11 @@ module.exports =
 /* 0 */
 /***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(__dirname) {const { sep } = __webpack_require__(1);
+const { sep } = __webpack_require__(1);
 
 const X = sep;
 
-fs.readFileSync(__dirname + '/asset.txt');
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
+fs.readFileSync(__webpack_require__.p + '/asset.txt');
 
 /***/ }),
 /* 1 */

--- a/test/unit/path-sep/output.js
+++ b/test/unit/path-sep/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -89,12 +90,11 @@ module.exports =
 /* 0 */
 /***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(__dirname) {const { sep } = __webpack_require__(1);
+const { sep } = __webpack_require__(1);
 
 const X = sep;
 
-fs.readFileSync(__dirname + '/asset.txt');
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
+fs.readFileSync(__webpack_require__.p + '/asset.txt');
 
 /***/ }),
 /* 1 */

--- a/test/unit/pkginfo/output-coverage.js
+++ b/test/unit/pkginfo/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/pkginfo/output.js
+++ b/test/unit/pkginfo/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/process-env/output-coverage.js
+++ b/test/unit/process-env/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/process-env/output.js
+++ b/test/unit/process-env/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/protobuf-loop/output-coverage.js
+++ b/test/unit/protobuf-loop/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -90,24 +91,23 @@ module.exports =
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-/* WEBPACK VAR INJECTION */(function(__dirname) {
+
 const path = __webpack_require__(1);
 // Load Google's well-known proto files that aren't exposed by Protobuf.js.
 {
     // Protobuf.js exposes: any, duration, empty, field_mask, struct, timestamp,
     // and wrappers. compiler/plugin is excluded in Protobuf.js and here.
     var wellKnownProtos = ['asset1', 'asset2'];
-    var sourceDir = __dirname + '/assets';
+    var sourceDir = __webpack_require__.p + '/assets';
     for (var _i = 0, wellKnownProtos_1 = wellKnownProtos; _i < wellKnownProtos_1.length; _i++) {
         var proto = wellKnownProtos_1[_i];
-        var file = __dirname + '/assets/' + proto + '.txt';
+        var file = __webpack_require__.p + '/assets/' + proto + '.txt';
         var descriptor_1 = Protobuf.loadSync(file).toJSON();
         // @ts-ignore
         Protobuf.common(proto, descriptor_1.nested.google.nested);
     }
 }
 //# sourceMappingURL=index.js.map
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
 
 /***/ }),
 /* 1 */

--- a/test/unit/protobuf-loop/output.js
+++ b/test/unit/protobuf-loop/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -90,24 +91,23 @@ module.exports =
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-/* WEBPACK VAR INJECTION */(function(__dirname) {
+
 const path = __webpack_require__(1);
 // Load Google's well-known proto files that aren't exposed by Protobuf.js.
 {
     // Protobuf.js exposes: any, duration, empty, field_mask, struct, timestamp,
     // and wrappers. compiler/plugin is excluded in Protobuf.js and here.
     var wellKnownProtos = ['asset1', 'asset2'];
-    var sourceDir = __dirname + '/assets';
+    var sourceDir = __webpack_require__.p + '/assets';
     for (var _i = 0, wellKnownProtos_1 = wellKnownProtos; _i < wellKnownProtos_1.length; _i++) {
         var proto = wellKnownProtos_1[_i];
-        var file = __dirname + '/assets/' + proto + '.txt';
+        var file = __webpack_require__.p + '/assets/' + proto + '.txt';
         var descriptor_1 = Protobuf.loadSync(file).toJSON();
         // @ts-ignore
         Protobuf.common(proto, descriptor_1.nested.google.nested);
     }
 }
 //# sourceMappingURL=index.js.map
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
 
 /***/ }),
 /* 1 */

--- a/test/unit/protobuf-loop2/output-coverage.js
+++ b/test/unit/protobuf-loop2/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -90,25 +91,24 @@ module.exports =
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-/* WEBPACK VAR INJECTION */(function(__dirname) {
+
 const path = __webpack_require__(1);
 // Load Google's well-known proto files that aren't exposed by Protobuf.js.
 {
     // Protobuf.js exposes: any, duration, empty, field_mask, struct, timestamp,
     // and wrappers. compiler/plugin is excluded in Protobuf.js and here.
     var wellKnownProtos = ['asset1', 'asset2'];
-    var sourceDir = __dirname + '/assets';
+    var sourceDir = __webpack_require__.p + '/assets';
     var _i;
     for (_i = 0; _i < wellKnownProtos_1.length; _i++) {
         var proto = wellKnownProtos[_i];
-        var file = __dirname + '/assets/' + proto + '.txt';
+        var file = __webpack_require__.p + '/assets/' + proto + '.txt';
         var descriptor_1 = Protobuf.loadSync(file).toJSON();
         // @ts-ignore
         Protobuf.common(proto, descriptor_1.nested.google.nested);
     }
 }
 //# sourceMappingURL=index.js.map
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
 
 /***/ }),
 /* 1 */

--- a/test/unit/protobuf-loop2/output.js
+++ b/test/unit/protobuf-loop2/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -90,25 +91,24 @@ module.exports =
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-/* WEBPACK VAR INJECTION */(function(__dirname) {
+
 const path = __webpack_require__(1);
 // Load Google's well-known proto files that aren't exposed by Protobuf.js.
 {
     // Protobuf.js exposes: any, duration, empty, field_mask, struct, timestamp,
     // and wrappers. compiler/plugin is excluded in Protobuf.js and here.
     var wellKnownProtos = ['asset1', 'asset2'];
-    var sourceDir = __dirname + '/assets';
+    var sourceDir = __webpack_require__.p + '/assets';
     var _i;
     for (_i = 0; _i < wellKnownProtos_1.length; _i++) {
         var proto = wellKnownProtos[_i];
-        var file = __dirname + '/assets/' + proto + '.txt';
+        var file = __webpack_require__.p + '/assets/' + proto + '.txt';
         var descriptor_1 = Protobuf.loadSync(file).toJSON();
         // @ts-ignore
         Protobuf.common(proto, descriptor_1.nested.google.nested);
     }
 }
 //# sourceMappingURL=index.js.map
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
 
 /***/ }),
 /* 1 */

--- a/test/unit/require-call/output-coverage.js
+++ b/test/unit/require-call/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/require-call/output.js
+++ b/test/unit/require-call/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/require-check/output-coverage.js
+++ b/test/unit/require-check/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/require-check/output.js
+++ b/test/unit/require-check/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/require-dirname-tpl/output-coverage.js
+++ b/test/unit/require-dirname-tpl/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/require-dirname-tpl/output.js
+++ b/test/unit/require-dirname-tpl/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/require-dynamic-fallback/output-coverage.js
+++ b/test/unit/require-dynamic-fallback/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/require-dynamic-fallback/output.js
+++ b/test/unit/require-dynamic-fallback/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/require-empty/output-coverage.js
+++ b/test/unit/require-empty/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/require-empty/output.js
+++ b/test/unit/require-empty/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/require-esm/output-coverage.js
+++ b/test/unit/require-esm/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/require-esm/output.js
+++ b/test/unit/require-esm/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/require-main/output-coverage.js
+++ b/test/unit/require-main/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/require-main/output.js
+++ b/test/unit/require-main/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/require-resolve-like/output-coverage.js
+++ b/test/unit/require-resolve-like/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/require-resolve-like/output.js
+++ b/test/unit/require-resolve-like/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/require-resolve/output-coverage.js
+++ b/test/unit/require-resolve/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -87,17 +88,16 @@ module.exports =
 /************************************************************************/
 /******/ ([
 /* 0 */
-/***/ (function(module, exports) {
+/***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(__dirname) {const asset1 = __dirname + '/asset1.txt';
+const asset1 = __webpack_require__.p + '/asset1.txt';
 
 function loader () {}
-loader(__dirname + '/asset2.txt');
+loader(__webpack_require__.p + '/asset2.txt');
 
-unknown(__dirname + '/asset1.txt');
+unknown(__webpack_require__.p + '/asset1.txt');
 
-const thing = asdf(__dirname + '/asset3.txt');
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
+const thing = asdf(__webpack_require__.p + '/asset3.txt');
 
 /***/ })
 /******/ ]);

--- a/test/unit/require-resolve/output.js
+++ b/test/unit/require-resolve/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -87,17 +88,16 @@ module.exports =
 /************************************************************************/
 /******/ ([
 /* 0 */
-/***/ (function(module, exports) {
+/***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(__dirname) {const asset1 = __dirname + '/asset1.txt';
+const asset1 = __webpack_require__.p + '/asset1.txt';
 
 function loader () {}
-loader(__dirname + '/asset2.txt');
+loader(__webpack_require__.p + '/asset2.txt');
 
-unknown(__dirname + '/asset1.txt');
+unknown(__webpack_require__.p + '/asset1.txt');
 
-const thing = asdf(__dirname + '/asset3.txt');
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
+const thing = asdf(__webpack_require__.p + '/asset3.txt');
 
 /***/ })
 /******/ ]);

--- a/test/unit/require-wrapper/output-coverage.js
+++ b/test/unit/require-wrapper/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/require-wrapper/output.js
+++ b/test/unit/require-wrapper/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/require-wrapper2/output-coverage.js
+++ b/test/unit/require-wrapper2/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/require-wrapper2/output.js
+++ b/test/unit/require-wrapper2/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/require-wrapper3/output-coverage.js
+++ b/test/unit/require-wrapper3/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/require-wrapper3/output.js
+++ b/test/unit/require-wrapper3/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/resolve-from/output-coverage.js
+++ b/test/unit/resolve-from/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/resolve-from/output.js
+++ b/test/unit/resolve-from/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/socket.io/output-coverage.js
+++ b/test/unit/socket.io/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -110,9 +111,9 @@ Server.prototype.serveClient = function(v){
     return require.resolve(file);
   };
   if (v && !clientSource) {
-    clientSource = read(__dirname + '/socket.io.js', 'utf-8');
+    clientSource = read(__webpack_require__.p + '/socket.io.js', 'utf-8');
     try {
-      clientSourceMap = read(__dirname + '/socket.io.js.map', 'utf-8');
+      clientSourceMap = read(__webpack_require__.p + '/socket.io.js.map', 'utf-8');
     } catch(err) {
       debug('could not load sourcemap file');
     }

--- a/test/unit/socket.io/output.js
+++ b/test/unit/socket.io/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -110,9 +111,9 @@ Server.prototype.serveClient = function(v){
     return require.resolve(file);
   };
   if (v && !clientSource) {
-    clientSource = read(__dirname + '/socket.io.js', 'utf-8');
+    clientSource = read(__webpack_require__.p + '/socket.io.js', 'utf-8');
     try {
-      clientSourceMap = read(__dirname + '/socket.io.js.map', 'utf-8');
+      clientSourceMap = read(__webpack_require__.p + '/socket.io.js.map', 'utf-8');
     } catch(err) {
       debug('could not load sourcemap file');
     }

--- a/test/unit/when-wrapper/output-coverage.js
+++ b/test/unit/when-wrapper/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/when-wrapper/output.js
+++ b/test/unit/when-wrapper/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/wildcard-require/output-coverage.js
+++ b/test/unit/wildcard-require/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/wildcard-require/output.js
+++ b/test/unit/wildcard-require/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/wildcard/output-coverage.js
+++ b/test/unit/wildcard/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -89,12 +90,11 @@ module.exports =
 /* 0 */
 /***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(__dirname) {const path = __webpack_require__(1);
+const path = __webpack_require__(1);
 
-fs.readFileSync(__dirname + '/assets/' + unknown + '.txt');
-fs.readFileSync(__dirname + '/assets/' + unknown.join('/') + '.txt');
+fs.readFileSync(__webpack_require__.p + '/assets/' + unknown + '.txt');
+fs.readFileSync(__webpack_require__.p + '/assets/' + unknown.join('/') + '.txt');
 
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
 
 /***/ }),
 /* 1 */

--- a/test/unit/wildcard/output.js
+++ b/test/unit/wildcard/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -89,12 +90,11 @@ module.exports =
 /* 0 */
 /***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(__dirname) {const path = __webpack_require__(1);
+const path = __webpack_require__(1);
 
-fs.readFileSync(__dirname + '/assets/' + unknown + '.txt');
-fs.readFileSync(__dirname + '/assets/' + unknown.join('/') + '.txt');
+fs.readFileSync(__webpack_require__.p + '/assets/' + unknown + '.txt');
+fs.readFileSync(__webpack_require__.p + '/assets/' + unknown.join('/') + '.txt');
 
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
 
 /***/ }),
 /* 1 */

--- a/test/unit/wildcard2/output-coverage.js
+++ b/test/unit/wildcard2/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -89,12 +90,11 @@ module.exports =
 /* 0 */
 /***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(__dirname) {const path = __webpack_require__(1);
+const path = __webpack_require__(1);
 
-fs.readFileSync(__dirname + '/wildcard2/' + unknown + '/asset1.txt');
+fs.readFileSync(__webpack_require__.p + '/wildcard2/' + unknown + '/asset1.txt');
 
 
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
 
 /***/ }),
 /* 1 */

--- a/test/unit/wildcard2/output.js
+++ b/test/unit/wildcard2/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports
@@ -89,12 +90,11 @@ module.exports =
 /* 0 */
 /***/ (function(module, exports, __webpack_require__) {
 
-/* WEBPACK VAR INJECTION */(function(__dirname) {const path = __webpack_require__(1);
+const path = __webpack_require__(1);
 
-fs.readFileSync(__dirname + '/wildcard2/' + unknown + '/asset1.txt');
+fs.readFileSync(__webpack_require__.p + '/wildcard2/' + unknown + '/asset1.txt');
 
 
-/* WEBPACK VAR INJECTION */}.call(this, "/"))
 
 /***/ }),
 /* 1 */

--- a/test/unit/wildcard3/output-coverage.js
+++ b/test/unit/wildcard3/output-coverage.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports

--- a/test/unit/wildcard3/output.js
+++ b/test/unit/wildcard3/output.js
@@ -79,6 +79,7 @@ module.exports =
 /******/
 /******/ 	// __webpack_public_path__
 /******/ 	__webpack_require__.p = "";
+/******/ 	__webpack_require__.p = __dirname;
 /******/
 /******/
 /******/ 	// Load entry module and return exports


### PR DESCRIPTION
This fixes https://github.com/zeit/webpack-asset-relocator-loader/issues/51 in that when we introduced code splitting builds, the relative asset referencing no longer works out property due to us not knowing which chunk a module is in to relatively locate the asset folder (and a module can be in many chunks as well).

We hook the output to set `__webpack_require__.p = __dirname` and then use `__webpack_public_path__` references for the asset loads to ensure things work out.

There is still an issue here though in working out from the `chunk` in the main template hook, where the `assets` folder is relative to the current chunk, so we shouldn't merge until that is resolved.