### PR TITLE
Remove __dirname filtering

### DIFF
--- a/src/asset-relocator.js
+++ b/src/asset-relocator.js
@@ -1098,9 +1098,6 @@ module.exports = async function (content, map) {
       wildcardSuffix = path.sep + WILDCARD;
     else if (assetPath.endsWith(WILDCARD))
       wildcardSuffix = WILDCARD;
-    // do not emit __dirname
-    if (assetPath === dir + wildcardSuffix)
-      return;
     // do not emit cwd
     if (assetPath === cwd + wildcardSuffix)
       return;

--- a/test/unit/asset-fs-inline-assign/output-coverage.js
+++ b/test/unit/asset-fs-inline-assign/output-coverage.js
@@ -96,7 +96,7 @@ console.log(fs.readFileSync(__dirname + '/asset.txt', 'utf8'));
 
 (function () {
   var join = () => 'nope';
-  console.log(fs.readFileSync(join(__dirname, 'asset.txt'), 'utf8'));
+  console.log(fs.readFileSync(join(__dirname + '/asset-fs-inline-assign', 'asset.txt'), 'utf8'));
 })();
 /* WEBPACK VAR INJECTION */}.call(this, "/"))
 

--- a/test/unit/asset-fs-inline-assign/output.js
+++ b/test/unit/asset-fs-inline-assign/output.js
@@ -96,7 +96,7 @@ console.log(fs.readFileSync(__dirname + '/asset.txt', 'utf8'));
 
 (function () {
   var join = () => 'nope';
-  console.log(fs.readFileSync(join(__dirname, 'asset.txt'), 'utf8'));
+  console.log(fs.readFileSync(join(__dirname + '/asset-fs-inline-assign', 'asset.txt'), 'utf8'));
 })();
 /* WEBPACK VAR INJECTION */}.call(this, "/"))
 

--- a/test/unit/asset-fs-inline-path-shadow/output.js
+++ b/test/unit/asset-fs-inline-path-shadow/output.js
@@ -96,7 +96,7 @@ console.log(fs.readFileSync(__dirname + '/asset.txt', 'utf8'));
 
 (function () {
   var join = () => 'nope';
-  console.log(fs.readFileSync(join(__dirname, 'asset.txt'), 'utf8'));
+  console.log(fs.readFileSync(join(__dirname + '/asset-fs-inline-path-shadow', 'asset.txt'), 'utf8'));
 })();
 /* WEBPACK VAR INJECTION */}.call(this, "/"))
 

--- a/test/unit/dirname-emit/input.js
+++ b/test/unit/dirname-emit/input.js
@@ -1,0 +1,2 @@
+const fs = require('fs');
+console.log(fs.readdirSync(__dirname));

--- a/test/unit/dirname-emit/output-coverage.js
+++ b/test/unit/dirname-emit/output-coverage.js
@@ -90,14 +90,8 @@ module.exports =
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(__dirname) {const fs = __webpack_require__(1);
-const { join } = __webpack_require__(2);
+console.log(fs.readdirSync(__dirname + '/dirname-emit'));
 
-console.log(fs.readFileSync(__dirname + '/asset.txt', 'utf8'));
-
-(function () {
-  var join = () => 'nope';
-  console.log(fs.readFileSync(join(__dirname + '/asset-fs-inline-path-shadow', 'asset.txt'), 'utf8'));
-})();
 /* WEBPACK VAR INJECTION */}.call(this, "/"))
 
 /***/ }),
@@ -105,12 +99,6 @@ console.log(fs.readFileSync(__dirname + '/asset.txt', 'utf8'));
 /***/ (function(module, exports) {
 
 module.exports = require("fs");
-
-/***/ }),
-/* 2 */
-/***/ (function(module, exports) {
-
-module.exports = require("path");
 
 /***/ })
 /******/ ]);

--- a/test/unit/dirname-emit/output.js
+++ b/test/unit/dirname-emit/output.js
@@ -90,14 +90,8 @@ module.exports =
 /***/ (function(module, exports, __webpack_require__) {
 
 /* WEBPACK VAR INJECTION */(function(__dirname) {const fs = __webpack_require__(1);
-const { join } = __webpack_require__(2);
+console.log(fs.readdirSync(__dirname + '/dirname-emit'));
 
-console.log(fs.readFileSync(__dirname + '/asset.txt', 'utf8'));
-
-(function () {
-  var join = () => 'nope';
-  console.log(fs.readFileSync(join(__dirname + '/asset-fs-inline-path-shadow', 'asset.txt'), 'utf8'));
-})();
 /* WEBPACK VAR INJECTION */}.call(this, "/"))
 
 /***/ }),
@@ -105,12 +99,6 @@ console.log(fs.readFileSync(__dirname + '/asset.txt', 'utf8'));
 /***/ (function(module, exports) {
 
 module.exports = require("fs");
-
-/***/ }),
-/* 2 */
-/***/ (function(module, exports) {
-
-module.exports = require("path");
 
 /***/ })
 /******/ ]);

--- a/test/unit/ffmpeg-installer/output-coverage.js
+++ b/test/unit/ffmpeg-installer/output-coverage.js
@@ -112,7 +112,7 @@ var packageName = '@ffmpeg-installer/' + platform;
 var binary = os.platform() === 'win32' ? 'ffmpeg.exe' : 'ffmpeg.exe';
 
 var npm3Path = path.resolve(__dirname, '..', platform);
-var npm2Path = path.resolve(__dirname, '.', platform);
+var npm2Path = __dirname + '/ffmpeg-installer';
 
 var npm3Binary = path.join(npm3Path, binary);
 var npm2Binary = __dirname + '/ffmpeg.exe';

--- a/test/unit/ffmpeg-installer/output.js
+++ b/test/unit/ffmpeg-installer/output.js
@@ -112,7 +112,7 @@ var packageName = '@ffmpeg-installer/' + platform;
 var binary = os.platform() === 'win32' ? 'ffmpeg.exe' : 'ffmpeg.exe';
 
 var npm3Path = path.resolve(__dirname, '..', platform);
-var npm2Path = path.resolve(__dirname, '.', platform);
+var npm2Path = __dirname + '/ffmpeg-installer';
 
 var npm3Binary = path.join(npm3Path, binary);
 var npm2Binary = __dirname + '/ffmpeg.exe';

--- a/test/unit/fs-emission/output-coverage.js
+++ b/test/unit/fs-emission/output-coverage.js
@@ -95,7 +95,7 @@ fs.readFile('./asset1.txt')
 
 fs.readFile(__dirname + '/asset2.txt')
 
-const _basePath = __dirname;
+const _basePath = __dirname + '/fs-emission';
 const asset3 = 'asset3.txt';
 fs.readFileSync(__dirname + '/asset3.txt', 'utf8');
 

--- a/test/unit/fs-emission/output.js
+++ b/test/unit/fs-emission/output.js
@@ -95,7 +95,7 @@ fs.readFile('./asset1.txt')
 
 fs.readFile(__dirname + '/asset2.txt')
 
-const _basePath = __dirname;
+const _basePath = __dirname + '/fs-emission';
 const asset3 = 'asset3.txt';
 fs.readFileSync(__dirname + '/asset3.txt', 'utf8');
 

--- a/test/unit/oracledb/output-coverage.js
+++ b/test/unit/oracledb/output-coverage.js
@@ -104,7 +104,7 @@ for (var i = 0; i < binaryLocations.length; i++) {
       var nodeInfo;
       if (err.code === 'MODULE_NOT_FOUND') {
         // none of the three binaries could be found
-        nodeInfo = `\n  Looked for ${binaryLocations.map(x => __webpack_require__(2).resolve(__dirname, x)).join(', ')}\n  ${nodbUtil.getInstallURL()}\n`;
+        nodeInfo = `\n  Looked for ${binaryLocations.map(x => __dirname + '/oracledb/' + x).join(', ')}\n  ${nodbUtil.getInstallURL()}\n`;
       } else {
         nodeInfo = `\n  Node.js require('oracledb') error was:\n  ${err.message}\n  ${nodbUtil.getInstallHelp()}\n`;
       }
@@ -120,12 +120,6 @@ for (var i = 0; i < binaryLocations.length; i++) {
 /***/ (function(module, exports) {
 
 module.exports = 'oracledb';
-
-/***/ }),
-/* 2 */
-/***/ (function(module, exports) {
-
-module.exports = require("path");
 
 /***/ })
 /******/ ]);

--- a/test/unit/oracledb/output.js
+++ b/test/unit/oracledb/output.js
@@ -104,7 +104,7 @@ for (var i = 0; i < binaryLocations.length; i++) {
       var nodeInfo;
       if (err.code === 'MODULE_NOT_FOUND') {
         // none of the three binaries could be found
-        nodeInfo = `\n  Looked for ${binaryLocations.map(x => __webpack_require__(2).resolve(__dirname, x)).join(', ')}\n  ${nodbUtil.getInstallURL()}\n`;
+        nodeInfo = `\n  Looked for ${binaryLocations.map(x => __dirname + '/oracledb/' + x).join(', ')}\n  ${nodbUtil.getInstallURL()}\n`;
       } else {
         nodeInfo = `\n  Node.js require('oracledb') error was:\n  ${err.message}\n  ${nodbUtil.getInstallHelp()}\n`;
       }
@@ -120,12 +120,6 @@ for (var i = 0; i < binaryLocations.length; i++) {
 /***/ (function(module, exports) {
 
 module.exports = 'oracledb';
-
-/***/ }),
-/* 2 */
-/***/ (function(module, exports) {
-
-module.exports = require("path");
 
 /***/ })
 /******/ ]);

--- a/test/unit/socket.io/output-coverage.js
+++ b/test/unit/socket.io/output-coverage.js
@@ -103,7 +103,7 @@ Server.prototype.serveClient = function(v){
   if (!arguments.length) return this._serveClient;
   this._serveClient = v;
   var resolvePath = function(file){
-    var filepath = path.resolve(__dirname, './../../', file);
+    var filepath = path.resolve(__dirname + '/socket.io', './../../', file);
     if (exists(filepath)) {
       return filepath;
     }

--- a/test/unit/socket.io/output.js
+++ b/test/unit/socket.io/output.js
@@ -103,7 +103,7 @@ Server.prototype.serveClient = function(v){
   if (!arguments.length) return this._serveClient;
   this._serveClient = v;
   var resolvePath = function(file){
-    var filepath = path.resolve(__dirname, './../../', file);
+    var filepath = path.resolve(__dirname + '/socket.io', './../../', file);
     if (exists(filepath)) {
       return filepath;
     }


### PR DESCRIPTION
This removes the filtering that restricts emitting any `__dirname` references on their own that aren't analyzable as larger expressions.

The result is the risk of emitting more entire package directories unnecessarily, but this doesn't break anything in the ncc integration tests.