### PR TITLE
Add asset filter customization

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,14 @@ Any `.node` files included will also support binary relocation.
           options: {
             // optional, base folder for asset emission (eg assets/name.ext)
             outputAssetBase: 'assets',
+            // optional, restrict asset emissions to only the given folder.
+            filterAssetBase: process.cwd(),
+            // optional, permit entire __dirname emission
+            // eg `const nonAnalyzable = __dirname` can emit everything in the folder
+            emitDirnameAll: false,
+            // optional, permit entire filterAssetBase emission
+            // eg `const nonAnalyzable = process.cwd()` can emit everything in the cwd()
+            emitFilterAssetBaseAll: false,
             // optional, a list of asset names already emitted or
             // defined that should not be emitted
             existingAssetNames: []

--- a/src/asset-relocator.js
+++ b/src/asset-relocator.js
@@ -1098,8 +1098,11 @@ module.exports = async function (content, map) {
       wildcardSuffix = path.sep + WILDCARD;
     else if (assetPath.endsWith(WILDCARD))
       wildcardSuffix = WILDCARD;
+    // do not emit __dirname
+    if (!options.emitDirnameAll && (assetPath === dir + wildcardSuffix))
+      return;
     // do not emit cwd
-    if (assetPath === cwd + wildcardSuffix)
+    if (!options.emitFilterAssetBaseAll && (assetPath === (options.filterAssetBase || cwd) + wildcardSuffix))
       return;
     // do not emit node_modules
     if (assetPath.endsWith(path.sep + 'node_modules' + wildcardSuffix))
@@ -1118,11 +1121,11 @@ module.exports = async function (content, map) {
         return;
       }
     }
-    // otherwise, do not emit assets outside of the cwd
-    else if (!assetPath.startsWith(cwd)) {
+    // otherwise, do not emit assets outside of the filterAssetBase
+    else if (!assetPath.startsWith(options.filterAssetBase || cwd)) {
       if (options.debugLog) {
         if (assetEmission(assetPath))
-          console.log('Skipping asset emission of ' + assetPath.replace(wildcardRegEx, '*') + ' for ' + id + ' as it is outside the process directory ' + cwd);
+          console.log('Skipping asset emission of ' + assetPath.replace(wildcardRegEx, '*') + ' for ' + id + ' as it is outside the filterAssetBase directory ' + (options.filterAssetBase || cwd));
       }
       return;
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const path = require("path");
 const webpack = require("webpack");
 const MemoryFS = require("memory-fs");
 
@@ -45,6 +46,9 @@ for (const unitTest of fs.readdirSync(`${__dirname}/unit`)) {
             loader: __dirname + (global.coverage ? "/../src/asset-relocator" : "/../"),
             options: {
               existingAssetNames: ['existing.txt'],
+              filterAssetBase: path.resolve('test'),
+              emitDirnameAll: true,
+              emitFilterAssetBaseAll: true,
               wrapperCompatibility: true,
               debugLog: true,
               production: true

--- a/test/unit/filter-asset-base/input.js
+++ b/test/unit/filter-asset-base/input.js
@@ -1,0 +1,2 @@
+const fs = require('fs');
+fs.readFileSync(__dirname + '/../../../package.json');

--- a/test/unit/filter-asset-base/output-coverage.js
+++ b/test/unit/filter-asset-base/output-coverage.js
@@ -89,38 +89,16 @@ module.exports =
 /* 0 */
 /***/ (function(module, exports, __webpack_require__) {
 
-"use strict";
-/* WEBPACK VAR INJECTION */(function(__dirname) {
-/*
- * Sets/gets whether client code is being served.
- *
- * @param {Boolean} v whether to serve client code
- * @return {Server|Boolean} self when setting or value when getting
- * @api public
- */
-
-Server.prototype.serveClient = function(v){
-  if (!arguments.length) return this._serveClient;
-  this._serveClient = v;
-  var resolvePath = function(file){
-    var filepath = path.resolve(__dirname + '/socket.io', './../../', file);
-    if (exists(filepath)) {
-      return filepath;
-    }
-    return require.resolve(file);
-  };
-  if (v && !clientSource) {
-    clientSource = read(resolvePath( 'socket.io-client/dist/socket.io.js'), 'utf-8');
-    try {
-      clientSourceMap = read(resolvePath( 'socket.io-client/dist/socket.io.js.map'), 'utf-8');
-    } catch(err) {
-      debug('could not load sourcemap file');
-    }
-  }
-  return this;
-};
+/* WEBPACK VAR INJECTION */(function(__dirname) {const fs = __webpack_require__(1);
+fs.readFileSync(__dirname + '/../../../package.json');
 
 /* WEBPACK VAR INJECTION */}.call(this, "/"))
+
+/***/ }),
+/* 1 */
+/***/ (function(module, exports) {
+
+module.exports = require("fs");
 
 /***/ })
 /******/ ]);

--- a/test/unit/filter-asset-base/output.js
+++ b/test/unit/filter-asset-base/output.js
@@ -89,38 +89,16 @@ module.exports =
 /* 0 */
 /***/ (function(module, exports, __webpack_require__) {
 
-"use strict";
-/* WEBPACK VAR INJECTION */(function(__dirname) {
-/*
- * Sets/gets whether client code is being served.
- *
- * @param {Boolean} v whether to serve client code
- * @return {Server|Boolean} self when setting or value when getting
- * @api public
- */
-
-Server.prototype.serveClient = function(v){
-  if (!arguments.length) return this._serveClient;
-  this._serveClient = v;
-  var resolvePath = function(file){
-    var filepath = path.resolve(__dirname + '/socket.io', './../../', file);
-    if (exists(filepath)) {
-      return filepath;
-    }
-    return require.resolve(file);
-  };
-  if (v && !clientSource) {
-    clientSource = read(resolvePath( 'socket.io-client/dist/socket.io.js'), 'utf-8');
-    try {
-      clientSourceMap = read(resolvePath( 'socket.io-client/dist/socket.io.js.map'), 'utf-8');
-    } catch(err) {
-      debug('could not load sourcemap file');
-    }
-  }
-  return this;
-};
+/* WEBPACK VAR INJECTION */(function(__dirname) {const fs = __webpack_require__(1);
+fs.readFileSync(__dirname + '/../../../package.json');
 
 /* WEBPACK VAR INJECTION */}.call(this, "/"))
+
+/***/ }),
+/* 1 */
+/***/ (function(module, exports) {
+
+module.exports = require("fs");
 
 /***/ })
 /******/ ]);

--- a/test/unit/socket.io/output.js
+++ b/test/unit/socket.io/output.js
@@ -110,9 +110,9 @@ Server.prototype.serveClient = function(v){
     return require.resolve(file);
   };
   if (v && !clientSource) {
-    clientSource = read(__dirname + '/socket.io.js', 'utf-8');
+    clientSource = read(resolvePath( 'socket.io-client/dist/socket.io.js'), 'utf-8');
     try {
-      clientSourceMap = read(__dirname + '/socket.io.js.map', 'utf-8');
+      clientSourceMap = read(resolvePath( 'socket.io-client/dist/socket.io.js.map'), 'utf-8');
     } catch(err) {
       debug('could not load sourcemap file');
     }


### PR DESCRIPTION
This allows some new configuration options for asset filter customization:

1. `filterAssetBase` the base path below which assets will never be emitted. This is necessary to fix a now-node bug.
2. `emitDirnameAll` - a boolean option to determine whether it is possible to emit the entire contents of the local directory with just a free `__dirname` referenece.
3. `emitFilterAssetBaseAll` - a boolean option to determine whether it is possible to emit the entire contents of the `filterAssetBase` by just referencing it.

(2) and (3) could be left out of this PR possibly too.