### PR TITLE
Fixup wildcard extension handling

### DIFF
--- a/src/asset-relocator.js
+++ b/src/asset-relocator.js
@@ -263,12 +263,12 @@ function generateWildcardRequire(dir, wildcardPath, wildcardParam, wildcardBlock
     if (!relPath.startsWith('../'))
       relPath = './' + relPath;
     let condition = index === 0 ? '  ' : '  else ';
-    if (trailingWildcard && arg.endsWith('.js'))
-      condition += `if (arg === ${arg} || arg === ${arg.substr(0, arg.length - 3)})`;
-    else if (trailingWildcard && arg.endsWith('.json'))
-      condition += `if (arg === ${arg} || arg === ${arg.substr(0, arg.length - 5)})`;
-    else if (trailingWildcard && arg.endsWith('.node'))
-      condition += `if (arg === ${arg} || arg === ${arg.substr(0, arg.length - 5)})`;
+    if (trailingWildcard && arg.endsWith('.js"'))
+      condition += `if (arg === ${arg} || arg === ${arg.substr(0, arg.length - 4)}")`;
+    else if (trailingWildcard && arg.endsWith('.json"'))
+      condition += `if (arg === ${arg} || arg === ${arg.substr(0, arg.length - 6)}")`;
+    else if (trailingWildcard && arg.endsWith('.node"'))
+      condition += `if (arg === ${arg} || arg === ${arg.substr(0, arg.length - 6)}")`;
     else
       condition += `if (arg === ${arg})`;
     condition += ` return require(${JSON.stringify(relPath)});`;

--- a/test/unit/wildcard-require/output-coverage.js
+++ b/test/unit/wildcard-require/output-coverage.js
@@ -91,9 +91,9 @@ module.exports =
 /***/ (function(module, exports, __webpack_require__) {
 
 function __ncc_wildcard$0 (arg) {
-  if (arg === "1.js") return __webpack_require__(1);
-  else if (arg === "2.js") return __webpack_require__(2);
-  else if (arg === "3.js") return __webpack_require__(3);
+  if (arg === "1.js" || arg === "1") return __webpack_require__(1);
+  else if (arg === "2.js" || arg === "2") return __webpack_require__(2);
+  else if (arg === "3.js" || arg === "3") return __webpack_require__(3);
 }
 const num = Math.ceil(Math.random() * 3, 0);
 

--- a/test/unit/wildcard-require/output.js
+++ b/test/unit/wildcard-require/output.js
@@ -91,9 +91,9 @@ module.exports =
 /***/ (function(module, exports, __webpack_require__) {
 
 function __ncc_wildcard$0 (arg) {
-  if (arg === "1.js") return __webpack_require__(1);
-  else if (arg === "2.js") return __webpack_require__(2);
-  else if (arg === "3.js") return __webpack_require__(3);
+  if (arg === "1.js" || arg === "1") return __webpack_require__(1);
+  else if (arg === "2.js" || arg === "2") return __webpack_require__(2);
+  else if (arg === "3.js" || arg === "3") return __webpack_require__(3);
 }
 const num = Math.ceil(Math.random() * 3, 0);
 


### PR DESCRIPTION
This fixes up the wildcard handling to ensure that wildcard matching is done both on the wildcard substitution with and without the default extension applied, to better match standard cases of eg `require('./path/' + dyn)` where `dyn` does not include the file extension.