### PR TITLE
Call addDependency on emitFile calls

### DIFF
--- a/src/asset-relocator.js
+++ b/src/asset-relocator.js
@@ -388,6 +388,7 @@ module.exports = async function (content, map) {
       }
       else {
         assetState.assetPermissions[assetBase(options.outputAssetBase) + name] = stats.mode;
+        this.addDependency(assetPath);
         this.emitFile(assetBase(options.outputAssetBase) + name, source);
       }
     });
@@ -436,6 +437,7 @@ module.exports = async function (content, map) {
         }
         else {
           assetState.assetPermissions[assetBase(options.outputAssetBase) + name + file.substr(assetDirPath.length)] = stats.mode;
+          this.addDependency(file);
           this.emitFile(assetBase(options.outputAssetBase) + name + file.substr(assetDirPath.length), source);
         }
       }));


### PR DESCRIPTION
This should fix https://github.com/zeit/ncc-watcher/pull/4.

The issue is that we were not including the relevant `addDependency` calls in the loader to ensure Webpack properly tracks the asset invalidations.