### PR TITLE
Update oracledb binding path

### DIFF
--- a/src/utils/special-cases.js
+++ b/src/utils/special-cases.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const resolve = require('resolve');
+const fs = require('fs');
 const handleWrappers = require('./wrappers.js');
 
 module.exports = function ({ id, code, pkgBase, ast, scope, magicString, emitAssetDirectory }) {
@@ -119,7 +120,9 @@ module.exports = function ({ id, code, pkgBase, ast, scope, magicString, emitAss
           statement.body.body[0].block.body[0].expression.right.arguments[0].property.name === 'i') {
         const arg = statement.body.body[0].block.body[0].expression.right.arguments[0];
         statement.body.body[0].block.body[0].expression.right.arguments = [{ type: 'Literal', value: '_' }];
-        const binaryName = 'oracledb-abi' + process.versions.modules + '-' + process.platform + '-' + process.arch + '.node';
+        const version = JSON.parse(fs.readFileSync(id.slice(0, -15) + 'package.json')).version;
+        const useVersion = Number(version.slice(0, version.indexOf('.'))) >= 4;
+        const binaryName = 'oracledb-' + (useVersion ? version : 'abi' + process.versions.modules) + '-' + process.platform + '-' + process.arch + '.node';
         magicString.overwrite(arg.start, arg.end, global._unit ? "'./oracledb.js'" : "'../build/Release/" + binaryName + "'");
         return { transformed: true };
       }


### PR DESCRIPTION
This updates the special case to handle the 4.x versions, necessary for the v12 update on ncc.