### PR TITLE
Compatibility with latest webpack beta 

### DIFF
--- a/src/asset-relocator.js
+++ b/src/asset-relocator.js
@@ -110,7 +110,17 @@ function getEntryIds (compilation) {
     else if (typeof compilation.options.entry === 'object') {
       try {
         return flattenArray(Object.values(compilation.options.entry)
-          .map(entry => typeof entry === "string" ? [entry] : flattenArray(Object.values(entry)))
+          .map(entry => {
+            if (typeof entry === "string") {
+              return [entry];
+            }
+
+            if (entry && Array.isArray(entry.import)) {
+              return entry.import;
+            }
+            
+            return [];
+          })
         ).map(entryString => resolve.sync(entryString, { extensions }));
       }
       catch (e) {

--- a/src/asset-relocator.js
+++ b/src/asset-relocator.js
@@ -306,7 +306,7 @@ function injectPathHook (compilation, outputAssetBase) {
         if (relBase.length)
           relBase = '/' + relBase;
       }
-      return `${source}\n${mainTemplate.requireFn}.ab = __dirname + ${JSON.stringify(relBase + '/' + assetBase(outputAssetBase))};`;
+      return `${source}\n__webpack_require__.ab = __dirname + ${JSON.stringify(relBase + '/' + assetBase(outputAssetBase))};`;
     });
   }
 }

--- a/src/asset-relocator.js
+++ b/src/asset-relocator.js
@@ -96,6 +96,7 @@ function getAssetState (options, compilation) {
   return lastState = state;
 }
 
+const flattenArray = arr => Array.prototype.concat.apply([], arr);
 function getEntryIds (compilation) {
   if (compilation.options.entry) {
     if (typeof compilation.options.entry === 'string') {
@@ -108,7 +109,9 @@ function getEntryIds (compilation) {
     }
     else if (typeof compilation.options.entry === 'object') {
       try {
-        return Object.values(compilation.options.entry).map(entry => resolve.sync(entry, { extensions }));
+        return flattenArray(Object.values(compilation.options.entry)
+          .map(entry => typeof entry === "string" ? [entry] : flattenArray(Object.values(entry)))
+        ).map(entryString => resolve.sync(entryString, { extensions }));
       }
       catch (e) {
         return;


### PR DESCRIPTION
Hello :wave:
In webpack@5.0.0-beta.16 and earlier betas, `compilation.options.entry` looks like this:

```json
{
   "bundle-tests.spec":{
      "import":[
         "/Users/test/bundle-tests.spec.ts"
      ]
   },
   "inner-folder/bundle-tests2.spec":{
      "import":[
         "/Users/test/inner-folder/bundle-tests2.spec.ts"
      ]
   }
}
```

`getEntryIds` doesn't take that into account, and it passes an object  to `resolve.sync`, which always throws `TypeError: Path must be a string.`

This PR also addresses:
```
[DEP_WEBPACK_MAIN_TEMPLATE_REQUIRE_FN] DeprecationWarning: MainTemplate.requireFn is deprecated (use "__webpack_require__")
```


Also, without that patch, `ncc`'s [build](https://github.com/zeit/ncc/blob/master/package.json#L11) [with webpack@5.0.0-beta.16](https://github.com/zeit/ncc/compare/master...yurynix:upgrade-webpack-to-latest-beta) doesn't
produce a runnable `./dist/ncc/cli.js`
