### PR TITLE
Upgrade rollup-pluginutils

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "node-gyp-build": "^4.2.1",
     "node-pre-gyp": "^0.12.0",
     "resolve": "^1.10.0",
-    "rollup-pluginutils": "^2.3.3",
+    "rollup-pluginutils": "^2.8.2",
     "socket.io-client": "^2.2.0",
     "sourcemap-codec": "^1.4.4",
     "webpack": "^4.29.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1711,6 +1711,11 @@ estree-walker@^0.6.0:
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.0.tgz#5d865327c44a618dde5699f763891ae31f257dae"
   integrity sha512-peq1RfVAVzr3PU/jL31RaOjUKLoZJpObQWJJ+LgfcxDUifyLZ1RjPQZTl0pzj2uJ45b7A7XpyppXvxdEqzo4rw==
 
+estree-walker@^0.6.1:
+  version "0.6.1"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
+  integrity sha1-UwSRQ/QMbrkYsjZx0f4yGfOhs2I=
+
 esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
@@ -4225,13 +4230,12 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rollup-pluginutils@^2.3.3:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.5.0.tgz#23be0f05ac3972ea7b08fc7870cb91fde5b23a09"
-  integrity sha512-9Muh1H+XB5f5ONmKMayUoTYR1EZwHbwJJ9oZLrKT5yuTf/RLIQ5mYIGsrERquVucJmjmaAW0Y7+6Qo1Ep+5w3Q==
+rollup-pluginutils@^2.8.2:
+  version "2.8.2"
+  resolved "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
+  integrity sha1-cvKvB0i1kjZNvTOJ5gDlqURKNR4=
   dependencies:
-    estree-walker "^0.6.0"
-    micromatch "^3.1.10"
+    estree-walker "^0.6.1"
 
 rsvp@^4.8.4:
   version "4.8.4"


### PR DESCRIPTION
When working with code that has empty catch block, I get the following error:
```
(node:31513) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'type' of null
    at extractNames (/Users/yurynix/someproject/node_modules/node_modules/@zeit/webpack-asset-relocator-loader/dist/index.js:11469:12)
    at /Users/yurynix/someproject/node_modules/node_modules/@zeit/webpack-asset-relocator-loader/dist/index.js:11484:7
    at Array.forEach (<anonymous>)
    at new Scope (/Users/yurynix/someproject/node_modules/node_modules/@zeit/webpack-asset-relocator-loader/dist/index.js:11483:28)
    at Object.enter (/Users/yurynix/someproject/node_modules/node_modules/@zeit/webpack-asset-relocator-loader/dist/index.js:11552:16)
    at visit (/Users/yurynix/someproject/node_modules/node_modules/@zeit/webpack-asset-relocator-loader/dist/index.js:40726:10)
    at visit (/Users/yurynix/someproject/node_modules/node_modules/@zeit/webpack-asset-relocator-loader/dist/index.js:40748:5)
    at visit (/Users/yurynix/someproject/node_modules/node_modules/@zeit/webpack-asset-relocator-loader/dist/index.js:40743:6)
    at visit (/Users/yurynix/someproject/node_modules/node_modules/@zeit/webpack-asset-relocator-loader/dist/index.js:40748:5)
    at visit (/Users/yurynix/someproject/node_modules/node_modules/@zeit/webpack-asset-relocator-loader/dist/index.js:40743:6)
(node:31513) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 4)
```

This comes from:
https://github.com/rollup/plugins/blob/846944cd282ed51e5a57b6132a84af3fa0d4f741/packages/pluginutils/src/attachScopes.ts#L114

And have been fixed at:
https://github.com/rollup/rollup-pluginutils/pull/70
`rollup-pluginutils@2.8.2`